### PR TITLE
Focus control

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "tesk9/modal",
     "summary": "Accessible modal component",
     "license": "BSD-3-Clause",
-    "version": "5.0.0",
+    "version": "5.0.1",
     "exposed-modules": [
         "Accessibility.Modal"
     ],

--- a/examples/Main.elm
+++ b/examples/Main.elm
@@ -135,12 +135,12 @@ view model =
                         , wrapMsg = identity
                         , title = ( "Three focusable elements modal", [] )
                         , content =
-                            \{ firstFocusableElement, lastFocusableElement } ->
+                            \{ firstFocusableElement, lastFocusableElement, autofocusOn } ->
                                 div [ style "display" "flex", style "justify-content" "space-between" ]
                                     [ a
                                         (Html.Attributes.href "#" :: firstFocusableElement)
                                         [ text "I'm a link!" ]
-                                    , button [ onClick Modal.close ] [ text "Close Modal" ]
+                                    , button [ onClick Modal.close, autofocusOn ] [ text "Close Modal" ]
                                     , a
                                         (Html.Attributes.href "#" :: lastFocusableElement)
                                         [ text "I'm a link!" ]

--- a/src/Accessibility/Modal.elm
+++ b/src/Accessibility/Modal.elm
@@ -89,7 +89,9 @@ update { dismissOnEscAndOverlayClick } msg model =
     case msg of
         OpenModal returnFocusTo ->
             ( Opened returnFocusTo
-            , Task.attempt Focused (focus firstId)
+            , focus autofocusId
+                |> Task.onError (\_ -> focus firstId)
+                |> Task.attempt Focused
             )
 
         CloseModal by ->
@@ -124,6 +126,7 @@ view :
         { onlyFocusableElement : List (Attribute msg)
         , firstFocusableElement : List (Attribute msg)
         , lastFocusableElement : List (Attribute msg)
+        , autofocusOn : Attribute Never
         }
         -> Html msg
     }
@@ -175,6 +178,7 @@ viewModal :
             { onlyFocusableElement : List (Attribute msg)
             , firstFocusableElement : List (Attribute msg)
             , lastFocusableElement : List (Attribute msg)
+            , autofocusOn : Attribute Never
             }
             -> Html msg
     }
@@ -204,6 +208,7 @@ viewModal config =
                 , id lastId
                 ]
                     |> List.map (Html.Attributes.map config.wrapMsg)
+            , autofocusOn = id autofocusId
             }
         ]
 
@@ -221,6 +226,11 @@ firstId =
 lastId : String
 lastId =
     "modal__last-focusable-element"
+
+
+autofocusId : String
+autofocusId =
+    "modal__autofocus-element"
 
 
 viewTitle : ( String, List (Attribute Never) ) -> Html Never

--- a/src/Accessibility/Modal.elm
+++ b/src/Accessibility/Modal.elm
@@ -105,7 +105,7 @@ update { dismissOnEscAndOverlayClick } msg model =
                     closeModal returnFocusTo
 
                 _ ->
-                    ( Closed, Cmd.none )
+                    ( model, Cmd.none )
 
         Focus id ->
             ( model, Task.attempt Focused (focus id) )

--- a/src/Accessibility/Modal.elm
+++ b/src/Accessibility/Modal.elm
@@ -126,7 +126,7 @@ view :
         { onlyFocusableElement : List (Attribute msg)
         , firstFocusableElement : List (Attribute msg)
         , lastFocusableElement : List (Attribute msg)
-        , autofocusOn : Attribute Never
+        , autofocusOn : Attribute msg
         }
         -> Html msg
     }
@@ -178,7 +178,7 @@ viewModal :
             { onlyFocusableElement : List (Attribute msg)
             , firstFocusableElement : List (Attribute msg)
             , lastFocusableElement : List (Attribute msg)
-            , autofocusOn : Attribute Never
+            , autofocusOn : Attribute msg
             }
             -> Html msg
     }


### PR DESCRIPTION
![modal focus controls](https://user-images.githubusercontent.com/8811312/63189878-dc0bff80-c019-11e9-844f-ed772d1e2126.gif)

Adds autofocusOn attribute to the config. Now, we can have our nice focus trap using first and last focusable elements, without requiring that the focus start on the first focusable element.